### PR TITLE
Add GPD model to qseek.

### DIFF
--- a/src/qseek/images/seisbench.py
+++ b/src/qseek/images/seisbench.py
@@ -31,6 +31,7 @@ ModelName = Literal[
     "EQTransformer",
     "OBSTransformer",
     "LFEDetect",
+    "GPD",
 ]
 
 
@@ -274,7 +275,11 @@ class SeisBench(ImageFunction):
         try:
             return self.seisbench_model.default_args["blinding"]
         except KeyError:
-            return self.seisbench_model._annotate_args["blinding"][1]
+            try:
+                return self.seisbench_model._annotate_args["blinding"][1]
+            except KeyError:
+                # Fix to run GPD model that should be improved.
+                return (0, 0)
 
     def get_blinding(self, sampling_rate: float) -> timedelta:
         scaled_blinding_samples = max(self.get_blinding_samples()) / self.rescale_input


### PR DESCRIPTION
The blinding is set to (0, 0) if the argument is not in the attributes. Maybe a better fix/check can be included