### PR TITLE
Update getting_started.md with HPC installation notes

### DIFF
--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,6 +18,16 @@ or
 pipx install git+https://github.com/pyrocko/qseek
 ```
 
+> **HPC/Cluster Users:** This package requires a C compiler to build extensions. If you don't load one, the installation will fail with a compilation error.
+>
+> **Example Error:**
+> ```text
+> building 'qseek.ext.array_tools' extension
+> error: command 'gcc' failed: No such file or directory
+> ERROR: Failed building editable for qseek
+> ```
+> **Solution:** Run `module load gcc` (or your cluster's equivalent) before installing.
+
 ## Running Qseek
 
 The main entry point in the executeable is the `qseek` command. The provided command line interface (CLI) and a JSON config file is all what is needed to run the program.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -18,16 +18,17 @@ or
 pipx install git+https://github.com/pyrocko/qseek
 ```
 
-> **HPC/Cluster Users:** This package requires a C compiler to build extensions. If you don't load one, the installation will fail with a compilation error.
->
-> **Example Error:**
-> ```text
-> building 'qseek.ext.array_tools' extension
-> error: command 'gcc' failed: No such file or directory
-> ERROR: Failed building editable for qseek
-> ```
-> **Solution:** Run `module load gcc` (or your cluster's equivalent) before installing.
+!!! note "HPC/Cluster Users"
+    This package requires a C compiler to build extensions. If you don't load one, the installation will fail with a compilation error.
 
+    **Example Error:**
+    ```text
+    building 'qseek.ext.array_tools' extension
+    error: command 'gcc' failed: No such file or directory
+    ERROR: Failed building editable for qseek
+    ```
+
+    **Solution:** Run `module load gcc` (or your cluster's equivalent) before installing.
 ## Running Qseek
 
 The main entry point in the executeable is the `qseek` command. The provided command line interface (CLI) and a JSON config file is all what is needed to run the program.

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -29,6 +29,7 @@ pipx install git+https://github.com/pyrocko/qseek
     ```
 
     **Solution:** Run `module load gcc` (or your cluster's equivalent) before installing.
+    Alternatively, you can explicitly specify the compiler when installing: `CC=gcc pip install git+https://github.com/pyrocko/qseek`
 ## Running Qseek
 
 The main entry point in the executeable is the `qseek` command. The provided command line interface (CLI) and a JSON config file is all what is needed to run the program.


### PR DESCRIPTION
## Purpose
During installation on an HPC cluster, I encountered a build failure when compiling the C extension `qseek.ext.array_tools` because the `gcc` module was not loaded.

This PR updates the documentation.

## Changes
- **Documentation**: Added a troubleshooting note in `index.md` (or `getting_started.md`) explaining that `module load gcc` is required for successful compilation on managed clusters.
- **Example Error**: Included a snippet of the `gcc` failure log inside the installation guide for better error-matching.