### PR TITLE
added StaLta Image

### DIFF
--- a/src/qseek/apps/qseek.py
+++ b/src/qseek/apps/qseek.py
@@ -457,6 +457,7 @@ def main() -> None:
             import qseek.waveforms.providers  # noqa: F401
             from qseek.corrections.base import TravelTimeCorrections
             from qseek.features.base import FeatureExtractor
+            from qseek.images.base import ImageFunction
             from qseek.magnitudes.base import EventMagnitudeCalculator
             from qseek.pre_processing.base import BatchPreProcessing
             from qseek.tracers.tracers import RayTracer
@@ -470,6 +471,7 @@ def main() -> None:
             module_classes = (
                 WaveformProvider,
                 BatchPreProcessing,
+                ImageFunction,
                 RayTracer,
                 FeatureExtractor,
                 EventMagnitudeCalculator,

--- a/src/qseek/images/__init__.py
+++ b/src/qseek/images/__init__.py
@@ -1,0 +1,19 @@
+from typing import Annotated, Union
+
+from pydantic import Field
+
+from qseek.images.base import ImageFunction
+from qseek.images.seisbench import SeisBench
+from qseek.images.sta_lta import StaLtaImage
+
+ImageFunctionType = Annotated[
+    Union[(ImageFunction, *ImageFunction.get_subclasses())],
+    Field(..., discriminator="image"),
+]
+
+__all__ = [
+    "ImageFunction",
+    "ImageFunctionType",
+    "SeisBench",
+    "StaLtaImage",
+]

--- a/src/qseek/images/base.py
+++ b/src/qseek/images/base.py
@@ -31,6 +31,11 @@ class ObservedArrival:
 class ImageFunction(BaseModel):
     image: Literal["base"] = "base"
 
+    @classmethod
+    def get_subclasses(cls) -> tuple[type[ImageFunction], ...]:
+        """Returns a tuple of all the subclasses of ImageFunction."""
+        return tuple(cls.__subclasses__())
+
     @property
     def name(self) -> str:
         return self.__class__.__name__

--- a/src/qseek/images/images.py
+++ b/src/qseek/images/images.py
@@ -8,17 +8,16 @@ from itertools import chain
 from pathlib import Path
 from typing import (
     TYPE_CHECKING,
-    Annotated,
     Any,
     AsyncIterator,
     ClassVar,
     Iterator,
     Tuple,
-    Union,
 )
 
 from pydantic import Field, PositiveInt, PrivateAttr, RootModel, computed_field
 
+from qseek.images import ImageFunctionType
 from qseek.images.base import ImageFunction
 from qseek.images.seisbench import SeisBench
 from qseek.stats import Stats
@@ -34,12 +33,6 @@ if TYPE_CHECKING:
 
 
 logger = logging.getLogger(__name__)
-
-
-ImageFunctionType = Annotated[
-    Union[SeisBench, ImageFunction],
-    Field(..., discriminator="image"),
-]
 
 
 class ImageFunctionsStats(Stats):
@@ -83,7 +76,7 @@ class ImageFunctionsStats(Stats):
 
 
 class ImageFunctions(RootModel):
-    root: list[ImageFunctionType] = [SeisBench()]
+    root: list[ImageFunctionType] = Field(default_factory=lambda: [SeisBench()])
 
     _queue: asyncio.Queue[Tuple[WaveformImages, WaveformBatch] | None] = PrivateAttr(
         asyncio.Queue(maxsize=QUEUE_SIZE)

--- a/src/qseek/images/seisbench.py
+++ b/src/qseek/images/seisbench.py
@@ -161,7 +161,7 @@ class PhaseNetImage(WaveformImage):
 
 
 class SeisBench(ImageFunction):
-    """PhaseNet image function. For more details see SeisBench documentation."""
+    """SeisBench AI image function. For more details see SeisBench documentation."""
 
     image: Literal["SeisBench"] = "SeisBench"
 

--- a/src/qseek/images/sta_lta.py
+++ b/src/qseek/images/sta_lta.py
@@ -1,0 +1,126 @@
+import asyncio
+import logging
+from datetime import timedelta
+from typing import Annotated, Literal
+
+import numpy as np
+from pydantic import Field, PositiveFloat
+from pyrocko.trace import Trace
+
+from qseek.images.base import ImageFunction, PhaseName, WaveformImage
+from qseek.utils import PhaseDescription
+
+logger = logging.getLogger(__name__)
+
+
+class StaLtaImage(WaveformImage): ...
+
+
+class StaLta(ImageFunction):
+    image: Literal["StaLta"] = "StaLta"
+
+    sta_seconds: PositiveFloat = Field(
+        default=0.5,
+        description="Short-term average (STA) window length in seconds. "
+        "Only used when `model` is `STA/LTA`.",
+    )
+    lta_seconds: PositiveFloat = Field(
+        default=10.0,
+        description="Long-term average (LTA) window length in seconds. "
+        "Only used when `model` is `STA/LTA`.",
+    )
+
+    phase_map: dict[PhaseName, str] = Field(
+        default={
+            "P": "cake:P",
+            "S": "cake:S",
+        },
+        description="Phase mapping from SeisBench PhaseNet to "
+        "Qseek travel time phases.",
+    )
+    weights: dict[PhaseName, Annotated[float, Field(strict=True, ge=0.0)]] = Field(
+        default={
+            "P": 1.0,
+            "S": 1.0,
+        },
+        description="Weights for each phase.",
+    )
+
+    async def prepare(self) -> None: ...
+
+    async def process_traces(self, traces: list[Trace]) -> list[StaLtaImage]:
+        """Process traces to generate image functions.
+
+        Args:
+            traces (list[Trace]): List of traces to process.
+
+        Returns:
+            list[WaveformImage]: List of image functions.
+        """
+        from obspy.signal.trigger import classic_sta_lta
+
+        def _compute_characteristic_functions() -> list[Trace]:
+            char_function_traces = []
+            for tr in traces:
+                obspy_tr = tr.to_obspy_trace()
+                sampling_rate = obspy_tr.stats.sampling_rate
+                sta_samples = max(1, int(self.stalta_sta_seconds * sampling_rate))
+                lta_samples = max(
+                    sta_samples + 1, int(self.stalta_lta_seconds * sampling_rate)
+                )
+                if obspy_tr.stats.npts <= lta_samples:
+                    logger.warning(
+                        "trace %s too short for STA/LTA (lta=%d samples, npts=%d)",
+                        ".".join(tr.nslc_id),
+                        lta_samples,
+                        obspy_tr.stats.npts,
+                    )
+                    continue
+                obspy_tr.data = classic_sta_lta(
+                    obspy_tr.data.astype(np.float64),
+                    sta_samples,
+                    lta_samples,
+                )
+                char_function_traces.append(obspy_tr.to_pyrocko_trace())
+            return char_function_traces
+
+        char_function_traces = await asyncio.to_thread(
+            _compute_characteristic_functions
+        )
+
+        p_traces = [tr for tr in char_function_traces if tr.channel.endswith("Z")]
+        s_traces = [tr for tr in char_function_traces if not tr.channel.endswith("Z")]
+
+        annotation_p = StaLtaImage(
+            image_function=self.name,
+            weight=self.weights["P"],
+            phase=self.phase_map["P"],
+            detection_half_width=self._detection_half_width(),
+            traces=p_traces,
+        )
+        annotation_s = StaLtaImage(
+            image_function=self.name,
+            weight=self.weights["S"],
+            phase=self.phase_map["S"],
+            detection_half_width=self._detection_half_width(),
+            traces=s_traces,
+        )
+        return [annotation_s, annotation_p]
+
+    def get_blinding(self) -> timedelta:
+        """Blinding duration for the image function. Added to padded waveforms.
+
+        Returns:
+            timedelta: The blinding duration for the image function.
+        """
+        raise NotImplementedError("must be implemented by subclass")
+
+    def get_provided_phases(self) -> tuple[PhaseDescription, ...]:
+        """Get the phases provided by the image function.
+
+        Returns:
+            tuple[PhaseDescription, ...]: The phases provided by the image function.
+        """
+        return ("P", "S")
+
+        raise NotImplementedError("must be implemented by subclass")

--- a/src/qseek/images/sta_lta.py
+++ b/src/qseek/images/sta_lta.py
@@ -1,22 +1,123 @@
 import asyncio
 import logging
-from datetime import timedelta
+from datetime import datetime, timedelta
 from typing import Annotated, Literal
 
 import numpy as np
+from obspy import Stream
+from obspy.signal.trigger import classic_sta_lta, trigger_onset
 from pydantic import Field, PositiveFloat
-from pyrocko.trace import Trace
+from pyrocko.obspy_compat import to_obspy_stream, to_pyrocko_traces
+from pyrocko.trace import NoData, Trace
 
-from qseek.images.base import ImageFunction, PhaseName, WaveformImage
-from qseek.utils import PhaseDescription
+from qseek.images.base import ImageFunction, ObservedArrival, PhaseName, WaveformImage
+from qseek.utils import PhaseDescription, to_datetime
 
 logger = logging.getLogger(__name__)
 
 
-class StaLtaImage(WaveformImage): ...
+def _compute_characteristic_functions(
+    stream: Stream,
+    sta_seconds: float,
+    lta_seconds: float,
+) -> list[Trace]:
+    char_function_traces = []
+    for tr in stream:
+        sampling_rate = tr.stats.sampling_rate
+        sta_samples = max(1, int(sta_seconds * sampling_rate))
+        lta_samples = max(sta_samples + 1, int(lta_seconds * sampling_rate))
+
+        if tr.stats.npts <= lta_samples:
+            logger.warning(
+                "trace %s too short for STA/LTA (lta=%d samples, npts=%d)",
+                ".".join(tr.nslc_id),
+                lta_samples,
+                tr.stats.npts,
+            )
+            continue
+        tr.data = classic_sta_lta(
+            tr.data.astype(np.float64),
+            sta_samples,
+            lta_samples,
+        )
+        char_function_traces.append(tr)
+
+    return char_function_traces
+
+
+class StaLtaImage(WaveformImage):
+    def search_phase_arrival(
+        self,
+        trace_idx: int,
+        event_time: datetime,
+        modelled_arrival: datetime,
+        search_window_seconds: float = 5.0,
+        threshold: float = 0.1,
+        detection_blinding_seconds: float = 1.0,
+    ) -> ObservedArrival | None:
+        """Search for the closest peak (pick) in the station's image functions.
+
+        Args:
+            trace_idx (int): Index of the trace.
+            event_time (datetime): Time of the event.
+            modelled_arrival (datetime): Time to search around.
+            search_window_seconds (float, optional): Total search length in seconds
+                around modelled arrival time. Defaults to 5.
+            threshold (float, optional): Threshold for detection. Defaults to 0.1.
+            detection_blinding_seconds (float, optional): Blinding time in seconds for
+                the peak detection. Defaults to 1 second.
+
+        Returns:
+            datetime | None: Time of arrival, None is none found.
+        """
+        trace = self.traces[trace_idx]
+        window_length = timedelta(seconds=search_window_seconds)
+        try:
+            search_trace = trace.chop(
+                tmin=(modelled_arrival - window_length / 2).timestamp(),
+                tmax=(modelled_arrival + window_length / 2).timestamp(),
+                inplace=False,
+            )
+        except NoData:
+            logger.warning("No data to pick phase arrival %s.", ".".join(trace.nslc_id))
+            return None
+
+        trigger = trigger_onset(
+            search_trace.data.astype(np.float64),
+            threshold,
+            threshold / 2,
+        )
+        if len(trigger) == 0:
+            return None
+        if len(trigger) > 1:
+            logger.warning(
+                "Multiple triggers found for %s, using the first one.",
+                ".".join(trace.nslc_id),
+            )
+            return None
+        trigger_on_idx = trigger[0][0]
+        times = search_trace.get_xdata()
+        trigger_time = times[trigger_on_idx]
+        trigger_delay = trigger_time - event_time.timestamp()
+
+        # Limit to post-event peaks
+        post_event_peaks = trigger_delay > 0.0
+        trigger_on_idx = trigger_on_idx[post_event_peaks]
+        trigger_time = trigger_time[post_event_peaks]
+
+        if not trigger_on_idx.size:
+            return None
+
+        return ObservedArrival(
+            time=to_datetime(trigger_time[0]),
+            detection_value=1.0,
+            phase=self.phase,
+        )
 
 
 class StaLta(ImageFunction):
+    """STA/LTA analytical characteristic function."""
+
     image: Literal["StaLta"] = "StaLta"
 
     sta_seconds: PositiveFloat = Field(
@@ -57,36 +158,16 @@ class StaLta(ImageFunction):
         Returns:
             list[WaveformImage]: List of image functions.
         """
-        from obspy.signal.trigger import classic_sta_lta
-
-        def _compute_characteristic_functions() -> list[Trace]:
-            char_function_traces = []
-            for tr in traces:
-                obspy_tr = tr.to_obspy_trace()
-                sampling_rate = obspy_tr.stats.sampling_rate
-                sta_samples = max(1, int(self.stalta_sta_seconds * sampling_rate))
-                lta_samples = max(
-                    sta_samples + 1, int(self.stalta_lta_seconds * sampling_rate)
-                )
-                if obspy_tr.stats.npts <= lta_samples:
-                    logger.warning(
-                        "trace %s too short for STA/LTA (lta=%d samples, npts=%d)",
-                        ".".join(tr.nslc_id),
-                        lta_samples,
-                        obspy_tr.stats.npts,
-                    )
-                    continue
-                obspy_tr.data = classic_sta_lta(
-                    obspy_tr.data.astype(np.float64),
-                    sta_samples,
-                    lta_samples,
-                )
-                char_function_traces.append(obspy_tr.to_pyrocko_trace())
-            return char_function_traces
+        stream = to_obspy_stream(traces)
 
         char_function_traces = await asyncio.to_thread(
-            _compute_characteristic_functions
+            _compute_characteristic_functions,
+            stream,
+            self.sta_seconds,
+            self.lta_seconds,
         )
+
+        traces = to_pyrocko_traces(char_function_traces)
 
         p_traces = [tr for tr in char_function_traces if tr.channel.endswith("Z")]
         s_traces = [tr for tr in char_function_traces if not tr.channel.endswith("Z")]


### PR DESCRIPTION
Computes classic STA/LTA characteristic functions for each trace from obspy. STA/LTA does not distinguish phases by design. As a convention, the vertical component is used to build the P-phase image, and horizontal components feed the S-phase image. 