### PR TITLE
Keep station magnitude info

### DIFF
--- a/src/qseek/apps/qseek.py
+++ b/src/qseek/apps/qseek.py
@@ -283,10 +283,7 @@ def main() -> None:
             nest_asyncio.apply()
             from qseek.search import Search
 
-            if args.rundir.is_file() and args.rundir.suffix in {
-                ".json",
-                ".JSON",
-            }:
+            if args.rundir.is_file() and args.rundir.suffix in {".json", ".JSON"}:
                 search_file = args.rundir
                 rundir = args.rundir.parent / args.rundir.stem
                 if not rundir.is_dir():
@@ -326,7 +323,7 @@ def main() -> None:
                 )
 
             squirrel.snuffle(
-                events=(None if show_observed else search.catalog.as_pyrocko_events()),
+                events=None if show_observed else search.catalog.as_pyrocko_events(),
                 markers=markers,
                 stations=search.stations.as_pyrocko_stations(),
             )
@@ -493,9 +490,7 @@ def main() -> None:
                             console.print_json(subclass().model_dump_json(indent=2))
 
                             if subclass.__name__ == "LocalMagnitude":
-                                from qseek.magnitudes.local_magnitude import (
-                                    ModelName,
-                                )
+                                from qseek.magnitudes.local_magnitude import ModelName
 
                                 models = get_args(ModelName)
                                 list = "\n".join(f"- {m}" for m in sorted(models))

--- a/src/qseek/apps/qseek.py
+++ b/src/qseek/apps/qseek.py
@@ -283,7 +283,10 @@ def main() -> None:
             nest_asyncio.apply()
             from qseek.search import Search
 
-            if args.rundir.is_file() and args.rundir.suffix in {".json", ".JSON"}:
+            if args.rundir.is_file() and args.rundir.suffix in {
+                ".json",
+                ".JSON",
+            }:
                 search_file = args.rundir
                 rundir = args.rundir.parent / args.rundir.stem
                 if not rundir.is_dir():
@@ -323,7 +326,7 @@ def main() -> None:
                 )
 
             squirrel.snuffle(
-                events=None if show_observed else search.catalog.as_pyrocko_events(),
+                events=(None if show_observed else search.catalog.as_pyrocko_events()),
                 markers=markers,
                 stations=search.stations.as_pyrocko_stations(),
             )
@@ -345,7 +348,12 @@ def main() -> None:
                     console.print(
                         f"Event {str(detection.time).split('.')[0]}:",
                         ", ".join(
-                            f"[bold]{m.magnitude}[/bold] {m.average:.2f}±{m.error:.2f}"
+                            (
+                                f"[bold]{m.magnitude}[/bold] "
+                                f"{m.average:.2f}±{m.error:.2f}"
+                                if m.average is not None and m.error is not None
+                                else f"[bold]{m.magnitude}[/bold] (insufficient stations)"
+                            )
                             for m in detection.magnitudes
                         ),
                     )
@@ -483,7 +491,9 @@ def main() -> None:
                             console.print_json(subclass().model_dump_json(indent=2))
 
                             if subclass.__name__ == "LocalMagnitude":
-                                from qseek.magnitudes.local_magnitude import ModelName
+                                from qseek.magnitudes.local_magnitude import (
+                                    ModelName,
+                                )
 
                                 models = get_args(ModelName)
                                 list = "\n".join(f"- {m}" for m in sorted(models))

--- a/src/qseek/magnitudes/base.py
+++ b/src/qseek/magnitudes/base.py
@@ -31,7 +31,7 @@ class StationLocalMagnitude(NamedTuple):
     distance_epi: float
     distance_hypo: float
     snr: float = 0.0
-    flag: str | None = None
+    flag: Literal["valid", "low_snr", "high_std"] = "valid"
 
 
 class EventMagnitude(BaseModel):
@@ -247,8 +247,10 @@ class StationAmplitudes(NamedTuple):
             peak_amp=float(peak_amp),
             noise=float(noise_amp),
             noise_std=float(noise_std),
-            distance_hypo=receiver.distance_to(event)
-            if not station_depth_only
-            else hypo_distance_only_station_depth(receiver, event),
+            distance_hypo=(
+                receiver.distance_to(event)
+                if not station_depth_only
+                else hypo_distance_only_station_depth(receiver, event)
+            ),
             distance_epi=receiver.surface_distance_to(event),
         )

--- a/src/qseek/magnitudes/base.py
+++ b/src/qseek/magnitudes/base.py
@@ -31,6 +31,7 @@ class StationLocalMagnitude(NamedTuple):
     distance_epi: float
     distance_hypo: float
     snr: float = 0.0
+    flag: str | None = None
 
 
 class EventMagnitude(BaseModel):

--- a/src/qseek/magnitudes/base.py
+++ b/src/qseek/magnitudes/base.py
@@ -247,10 +247,8 @@ class StationAmplitudes(NamedTuple):
             peak_amp=float(peak_amp),
             noise=float(noise_amp),
             noise_std=float(noise_std),
-            distance_hypo=(
-                receiver.distance_to(event)
-                if not station_depth_only
-                else hypo_distance_only_station_depth(receiver, event)
-            ),
+            distance_hypo=receiver.distance_to(event)
+            if not station_depth_only
+            else hypo_distance_only_station_depth(receiver, event),
             distance_epi=receiver.surface_distance_to(event),
         )

--- a/src/qseek/magnitudes/local_magnitude.py
+++ b/src/qseek/magnitudes/local_magnitude.py
@@ -249,12 +249,7 @@ class LocalMagnitude(EventMagnitudeCalculator):
                     asyncio.to_thread(
                         tr.transfer,
                         transfer_function=transfer_function,
-                        freqlimits=(
-                            0.1,
-                            1.0,
-                            0.40 / tr.deltat,
-                            0.45 / tr.deltat,
-                        ),
+                        freqlimits=(0.1, 1.0, 0.40 / tr.deltat, 0.45 / tr.deltat),
                         tfade=self.taper_seconds,
                         cut_off_fading=False,
                         demean=True,

--- a/src/qseek/magnitudes/local_magnitude.py
+++ b/src/qseek/magnitudes/local_magnitude.py
@@ -70,26 +70,36 @@ class EventLocalMagnitude(EventMagnitude):
         if not station_magnitudes:
             raise ValueError("No station magnitudes provided")
 
-        std = np.std([sta.magnitude for sta in station_magnitudes])
-        unclean_mean = np.mean([sta.magnitude for sta in station_magnitudes])
+        valid_magnitudes = [sta for sta in station_magnitudes if sta.flag is None]
 
-        for mag in station_magnitudes.copy():
+        std = np.std([sta.magnitude for sta in valid_magnitudes])
+        unclean_mean = np.mean([sta.magnitude for sta in valid_magnitudes])
+
+        for i, mag in enumerate(station_magnitudes.copy()):
+            if mag.flag is not None:
+                continue
             if np.abs(mag.magnitude - unclean_mean) > max_station_std * std:
                 logger.warning(
                     "%s magnitude removed due to high std",
                     mag.station.pretty,
                 )
-                station_magnitudes.remove(mag)
+                station_magnitudes[i].flag = "high_std"
 
-        if len(station_magnitudes) < min_stations:
-            raise ValueError(
+        valid_magnitudes = [sta for sta in station_magnitudes if sta.flag is None]
+        if len(valid_magnitudes) < min_stations:
+            ml.station_magnitudes = station_magnitudes
+            ml.average = float(np.nan)
+            ml.error = float(np.nan)
+            logger.warning(
                 "Not enough station magnitudes available for local magnitude "
                 "calculation after removing outliers."
             )
+            return ml
 
         ml.station_magnitudes = station_magnitudes
-        magnitudes = np.array([sta.magnitude for sta in ml.station_magnitudes])
-        station_errors = np.array([sta.error for sta in ml.station_magnitudes])
+
+        magnitudes = np.array([sta.magnitude for sta in valid_magnitudes])
+        station_errors = np.array([sta.error for sta in valid_magnitudes])
         n = len(magnitudes)
         median = np.median(magnitudes)
 
@@ -321,7 +331,7 @@ class LocalMagnitude(EventMagnitudeCalculator):
                     nsl,
                     sta_mag.snr,
                 )
-                continue
+                sta_mag.flag = "low_snr"
             station_magnitudes.append(sta_mag)
 
         return EventLocalMagnitude.from_station_magnitudes(

--- a/src/qseek/magnitudes/local_magnitude.py
+++ b/src/qseek/magnitudes/local_magnitude.py
@@ -83,13 +83,11 @@ class EventLocalMagnitude(EventMagnitude):
                     "%s magnitude removed due to high std",
                     mag.station.pretty,
                 )
-                station_magnitudes[i].flag = "high_std"
+                station_magnitudes[i] = mag._replace(flag="high_std")
 
         valid_magnitudes = [sta for sta in station_magnitudes if sta.flag is None]
         if len(valid_magnitudes) < min_stations:
             ml.station_magnitudes = station_magnitudes
-            ml.average = float(np.nan)
-            ml.error = float(np.nan)
             logger.warning(
                 "Not enough station magnitudes available for local magnitude "
                 "calculation after removing outliers."
@@ -251,7 +249,12 @@ class LocalMagnitude(EventMagnitudeCalculator):
                     asyncio.to_thread(
                         tr.transfer,
                         transfer_function=transfer_function,
-                        freqlimits=(0.1, 1.0, 0.40 / tr.deltat, 0.45 / tr.deltat),
+                        freqlimits=(
+                            0.1,
+                            1.0,
+                            0.40 / tr.deltat,
+                            0.45 / tr.deltat,
+                        ),
                         tfade=self.taper_seconds,
                         cut_off_fading=False,
                         demean=True,
@@ -331,7 +334,7 @@ class LocalMagnitude(EventMagnitudeCalculator):
                     nsl,
                     sta_mag.snr,
                 )
-                sta_mag.flag = "low_snr"
+                sta_mag = sta_mag._replace(flag="low_snr")
             station_magnitudes.append(sta_mag)
 
         return EventLocalMagnitude.from_station_magnitudes(

--- a/src/qseek/magnitudes/local_magnitude_models.py
+++ b/src/qseek/magnitudes/local_magnitude_models.py
@@ -107,6 +107,9 @@ class StationLocalMagnitude(NamedTuple):
     distance_epi: float
     distance_hypo: float
     snr: float = 0.0
+    flag: str | None = (
+        None  # None -> valid magnitude, "low_snr" and "high_std" -> invalid magnitude
+    )
 
 
 class LocalMagnitudeModel:

--- a/src/qseek/magnitudes/local_magnitude_models.py
+++ b/src/qseek/magnitudes/local_magnitude_models.py
@@ -262,7 +262,7 @@ class CaliforniaIntegratedSeismicNetwork(WoodAnderson, LocalMagnitudeModel):
     doi = "10.1785/0120100106"
 
     epicentral_range = Range(0.0 * KM, 450.0 * KM)  # actually 500
-    component = "north-east-separate"
+    component = "horizontal-separate"
     max_amplitude = "wood-anderson-old"
     peak_measurement = "max-amplitude"
 

--- a/src/qseek/magnitudes/local_magnitude_models.py
+++ b/src/qseek/magnitudes/local_magnitude_models.py
@@ -107,9 +107,7 @@ class StationLocalMagnitude(NamedTuple):
     distance_epi: float
     distance_hypo: float
     snr: float = 0.0
-    flag: str | None = (
-        None  # None -> valid magnitude, "low_snr" and "high_std" -> invalid magnitude
-    )
+    flag: Literal["valid", "low_snr", "high_std"] = "valid"
 
 
 class LocalMagnitudeModel:

--- a/src/qseek/models/detection.py
+++ b/src/qseek/models/detection.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import logging
+import math
 from collections import defaultdict
 from datetime import datetime, timedelta, timezone
 from functools import cached_property
@@ -896,6 +897,10 @@ class EventDetection(Location):
         for magnitude in self.magnitudes:
             csv_line.update(magnitude.csv_row())
         csv_line["WKT_geom"] = self.as_wkt()
+
+        for key, value in csv_line.items():
+            if value is None or (isinstance(value, float) and math.isnan(value)):
+                csv_line[key] = ""
         return csv_line
 
     @classmethod

--- a/src/qseek/utils.py
+++ b/src/qseek/utils.py
@@ -781,7 +781,7 @@ class ChannelSelectors:
     HorizontalAvg = ChannelSelector("EN123RT", number_channels=2, average=True)
     Horizontal = ChannelSelector("EN123RT", number_channels=2)
     Vertical = ChannelSelector("Z0", number_channels=1)
-    NorthEast = ChannelSelector("NE", number_channels=2)
+    NorthEast = ChannelSelector("NE12", number_channels=2)
 
 
 def _dedent(text: str) -> str:

--- a/src/qseek/utils.py
+++ b/src/qseek/utils.py
@@ -793,7 +793,7 @@ class ChannelSelectors:
     HorizontalAvg = ChannelSelector("EN123RT", number_channels=2, average=True)
     Horizontal = ChannelSelector("EN123RT", number_channels=2)
     Vertical = ChannelSelector("Z0", number_channels=1)
-    NorthEast = ChannelSelector("NE12", number_channels=2)
+    NorthEast = ChannelSelector("NE", number_channels=2)
 
 
 def _dedent(text: str) -> str:


### PR DESCRIPTION
## Summary
Extends the magnitude output in `detections.json` to retain all calculated station magnitudes, flagging rejected stations rather than dropping them entirely.

## Motivation
Previously, station magnitudes were discarded if their SNR fell below a threshold or if they deviated significantly from the median magnitude. Retaining these flagged entries enables easier parameter testing and post-processing.

## Changes
- Updated `detections.json` output to keep all computed station magnitudes.
- Added a flag field (e.g., `"low_snr"`,`"high_std"`, `null`) as the last element of each station magnitude array to indicate whether it was excluded from the median calculation.

---

### Output Examples

**Station Magnitude Schema:** 
`[NSL, magnitude, error, amplitude, dist_epi, dist_hypo, snr, flag]`

#### 1. Incomplete / Rejected Event Calculation
*One station rejected due to low SNR (`"low_snr"`), resulting in an uncalculated event average (`null`):*

```json
"magnitudes": [
  {
    "magnitude": "LocalMagnitude",
    "average": null,
    "error": null,
    "station_magnitudes": [
      [["9J", "ER039", ""], 1.427, 0.468, 0.00059, 9765.0, 9994.4, 0.514, "low_snr"],
      [["9J", "ER045", ""], 1.605, 0.160, 0.00092, 9637.5, 9826.6, 2.829, null]
    ],
    "model": "california-integrated-seismic-network"
  }
]
#### 1. Complete Event Calculation
*One station rejected due to low SNR (`"low_snr"`), resulting in an uncalculated event average (`null`):*

"magnitudes": [
  {
    "magnitude": "LocalMagnitude",
    "average": 2.054,
    "error": 0.173,
    "station_magnitudes": [
      [["9J", "ER027", ""], 2.253, 0.225, 0.00319, 11266.0, 11674.4, 2.095, null],
      [["9J", "ER039", ""], 1.390, 0.509, 0.00039, 12351.0, 12601.1, 1.211, null],
      [["9J", "ER045", ""], 2.054, 0.115, 0.00168, 12865.5, 13147.2, 3.847, null]
    ],
    "model": "california-integrated-seismic-network"
  }
]
