### PR TITLE
 prepare stations in case feature-extraction

### DIFF
--- a/src/qseek/apps/qseek.py
+++ b/src/qseek/apps/qseek.py
@@ -334,7 +334,6 @@ def main() -> None:
             from qseek.search import Search
 
             search = Search.load_rundir(args.rundir)
-            search.data_provider.prepare(search.stations)
             recalculate_magnitudes = args.recalculate
 
             tasks = []
@@ -360,6 +359,10 @@ def main() -> None:
             )
 
             async def worker() -> None:
+                search.stations.prepare(search.octree.location)
+                await search.data_provider.prepare(search.stations)
+                search.stations.filter_stations(search.data_provider.available_nsls())
+
                 for magnitude in search.magnitudes:
                     await magnitude.prepare(search.octree, search.stations)
                 await search.catalog.check(repair=True)


### PR DESCRIPTION
## Summary

Fixes `feature-extraction` failing with `cannot get effective response` for all stations by preparing station and waveform data the same way as `search` before computing magnitudes.

## Motivation

Running `qseek search` with magnitudes calculates magnitudes successfully for most stations. However, running `qseek feature-extraction` afterward resulted in the error `cannot get effective response` for all stations.

The root cause was that the `feature-extraction` processing path did not prepare station metadata and responses before magnitude computation. Additionally, it called provider preparation without `await`.

## Changes

* Removed the non-awaited provider preparation call from the `feature-extraction` command path.
* Added full station and waveform preparation in `qseek.py`, mirroring the preparation already performed by `search`.
