### PR TITLE
correct selection of valid magnitude events from flag "None" to "valid"

### DIFF
--- a/src/qseek/magnitudes/local_magnitude.py
+++ b/src/qseek/magnitudes/local_magnitude.py
@@ -70,7 +70,7 @@ class EventLocalMagnitude(EventMagnitude):
         if not station_magnitudes:
             raise ValueError("No station magnitudes provided")
 
-        valid_magnitudes = [sta for sta in station_magnitudes if sta.flag is None]
+        valid_magnitudes = [sta for sta in station_magnitudes if sta.flag == "valid"]
 
         std = np.std([sta.magnitude for sta in valid_magnitudes])
         unclean_mean = np.mean([sta.magnitude for sta in valid_magnitudes])
@@ -85,7 +85,7 @@ class EventLocalMagnitude(EventMagnitude):
                 )
                 station_magnitudes[i] = mag._replace(flag="high_std")
 
-        valid_magnitudes = [sta for sta in station_magnitudes if sta.flag is None]
+        valid_magnitudes = [sta for sta in station_magnitudes if sta.flag == "valid"]
         if len(valid_magnitudes) < min_stations:
             ml.station_magnitudes = station_magnitudes
             logger.warning(


### PR DESCRIPTION
## Summary
Fix a leftover `flag is None` check that should have been updated to `flag == "valid"` when `StationLocalMagnitude.flag` was migrated from `str | None` to a `Literal["valid", "low_snr", "high_std"]` with `"valid"` as the default.

## Bug
`valid_magnitudes` was filtering with:

```python
valid_magnitudes = [sta for sta in station_magnitudes if sta.flag is None]
```

Since `flag` no longer defaults to `None` (it defaults to `"valid"`), this check never matched anything, so no station magnitudes were ever considered valid in the output csv.

## Fix
```python
valid_magnitudes = [sta for sta in station_magnitudes if sta.flag == "valid"]
```